### PR TITLE
add temp filter on workflow completeness

### DIFF
--- a/src/reducers/workflows.js
+++ b/src/reducers/workflows.js
@@ -18,7 +18,7 @@ export function workflows(state = initialState, action) {
         workflowsFetched: true,
         allWorkflows: action.json.filter(w => !w.display_name.match(/Template/i)),
         activeWorkflows: action.json.filter(w => w.active),
-        inactiveWorkflows: action.json.filter(w => !w.active && !w.display_name.match(/Template/i)),
+        inactiveWorkflows: action.json.filter(w => !w.active && !w.display_name.match(/Template/i) && w.completeness === 1),
       });
 
     default:


### PR DESCRIPTION
add temp filter on workflow completeness

will prevent workflows in progress from being displayed under Completed Expeditions

see issue #55 for additional info, but doesn't close issue
