### PR TITLE
Remove duplicate images from recent transcriptions #70

### DIFF
--- a/src/helpers/subjects.js
+++ b/src/helpers/subjects.js
@@ -8,7 +8,7 @@ export const getSubjectIds = (subjects) => {
 };
 
 export const transcriptionImages = subjects =>
-  subjects.map((s) => {
+  subjects.filter((id, i, self) => self.indexOf(id) === i).map((s) => {
     const img = {
       src: s.locations[0]['image/jpeg'],
       alt: s.metadata.Filename,


### PR DESCRIPTION
This may or may not be related to issue #63. This patch should fix it either way.
