### PR TITLE
Update packages causing console and server errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
     "react-redux": "^4.4.0",
-    "react-router": "2.1.0",
+    "react-router": "^2.1.0",
     "redux": "^3.3.1",
     "redux-logger": "^2.5.2",
     "redux-thunk": "^2.0.1"


### PR DESCRIPTION
Unpinning react-router version. The current version was causing console errors. If there is not specific reason to lock the version then we should treat this package like all of the other ones.
