### PR TITLE
edit completeness calc

### DIFF
--- a/src/actions/workflows.js
+++ b/src/actions/workflows.js
@@ -11,7 +11,7 @@ function workflowsReceived(json) {
 }
 
 export function fetchWorkflows() {
-  const fields = 'active,completeness,display_name,finished_at';
+  const fields = 'active,classifications_count,completeness,display_name,finished_at,retirement,subjects_count';
   let page = 1;
   return dispatch => {
     dispatch(workflowsRequested());

--- a/src/pages/active-expeditions.jsx
+++ b/src/pages/active-expeditions.jsx
@@ -23,7 +23,7 @@ const ActiveExpeditions = ({ params, activeWorkflows }) => {
           { expeditions.length
             ? expeditions.map((workflow, i) => {
               const expedition = findExpedition(workflow.display_name);
-              const percent = workflow.completeness * 100.0;
+              const percent = (workflow.classifications_count / (workflow.subjects_count * workflow.retirement.options.count)) * 100.0;
               return (
                 <div className="tile" key={i}>
                   <a href={`${config.workflowUrl}workflow=${workflow.id}`}


### PR DESCRIPTION
Closes #194 

changes completeness calc from `completeness` property of workflow resource, which is based on subjects retired, to a calc based on classifications, to match the current selected "Completeness statistic" option for workflows within the Project Builder/Visibility section for how they're displayed on the Stats page.

unfortunately if the "Completeness statistic" option within Project Builder/Visibility is changed, how we calculate completeness on the landing page will also have to be changed back.