### PR TITLE
Resize icons so they do not run off the screen Fixes #217

### DIFF
--- a/src/components/icons/caddisfly.jsx
+++ b/src/components/icons/caddisfly.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const CaddisflyIcon = () =>
-	<svg viewBox="-40 20 600 430" className="expedition-group-icon">
+	<svg viewBox="-40 20 600 430" className="expedition-group-icon shrink">
 		<g>
 			<path d="M336.2,164.8c1.2-0.1,2.4-0.2,3.6-0.3c-0.3-0.4-0.6-0.8-0.8-1.3C338,163.7,337.1,
 				164.3,336.2,164.8z"

--- a/src/components/icons/idea.jsx
+++ b/src/components/icons/idea.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const IdeaIcon = () =>
-  <svg viewBox="-500 0 4200 5000" className="expedition-group-icon fill-it">
+  <svg viewBox="-500 0 4200 5000" className="expedition-group-icon fill-it shrink">
   <path d="m 1639.915,3450.6944 c -91.8228,-54.1823 -301.9898,-150.7638 -239.9045,
     -279.1637 162.0394,56.9572 349.0535,39.4839 501.9486,-37.7807 33.0888,132.4722
     -119.8915,272.6971 -232.3838,317.5143 l -29.6603,-0.5699 0,0 z m -74.29,-305.2268

--- a/src/styles/components/expedition-group.styl
+++ b/src/styles/components/expedition-group.styl
@@ -20,6 +20,9 @@
       stroke-width: 1px
       border: 2px solid rgba(0, 0, 0, 0)
 
+      &.shrink
+        transform: scale(0.8)
+
       &.fill-it
         fill: rgba(0, 0, 0, 0.3)
 


### PR DESCRIPTION
@mcbouslog, As per your observation that some of the icons were not fitting on the expedition group pages properly.