### PR TITLE
add filter for workflows included in expeditions constant

### DIFF
--- a/src/helpers/expeditions.js
+++ b/src/helpers/expeditions.js
@@ -3,6 +3,11 @@ import dateformat from 'dateformat';
 
 const RECENT_EXPEDITIONS_LENGTH = 4;
 
+export function filterIfExpeditionConstant(expeditionList) {
+  return expeditionList.filter(workflow =>
+    Object.keys(expeditions).indexOf(workflow.display_name) !== -1);
+}
+
 export function findExpedition(workflow) {
   const displayName = workflow ? workflow.display_name : '';
   const expedition = expeditions[displayName] || expeditions.DEFAULT;

--- a/src/pages/completed-expeditions.jsx
+++ b/src/pages/completed-expeditions.jsx
@@ -4,10 +4,11 @@ import { Hero } from 'components/hero';
 import { FatFooter } from 'components/fat-footer';
 import { ExpeditionGroupIcons } from 'components/expedition-group-icons';
 import CompletedExpeditionTile from 'components/completed-expedition-tile';
-import { findExpedition, expeditionCompleted } from 'helpers/expeditions';
+import { filterIfExpeditionConstant, findExpedition, expeditionCompleted } from 'helpers/expeditions'; // eslint-disable-line max-len
 
 const CompletedExpeditions = ({ inactiveWorkflows }) => {
-  const expeditions = inactiveWorkflows.map(workflow => {
+  const filteredWorkflows = filterIfExpeditionConstant(inactiveWorkflows);
+  const expeditions = filteredWorkflows.map(workflow => {
     const expedition = findExpedition(workflow);
     expedition.completed = expeditionCompleted(expedition);
     return expedition;


### PR DESCRIPTION
closes #265 

Filters inactive workflows for completed expeditions page to only show workflows that are included in the expeditions constant.

Compare:
current: https://www.notesfromnature.org/completed-expeditions
this PR: https://relaunch.notesfromnature.org/completed-expeditions

Not wild about the name, but couldn't think of anything else.