### PR TITLE
field-book requests refactor

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,9 +2,6 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { fetchProject } from 'actions/project';
 import { fetchWorkflows } from 'actions/workflows';
-import { fetchProjectPreferences, fetchOldProjectPreferences } from 'actions/project-preferences';
-import { fetchRecents } from 'actions/recents';
-import { fetchTalkUser } from 'actions/talk';
 import * as status from 'constants/statuses';
 
 class App extends Component {
@@ -22,20 +19,6 @@ class App extends Component {
     }
     if (props.workflows.status === status.FETCH_READY) {
       this.props.dispatch(fetchWorkflows());
-    }
-    if (props.user && props.user.id) {
-      if (props.projectPreferences.status === status.FETCH_READY) {
-        props.dispatch(fetchProjectPreferences(props.user.id));
-      }
-      if (props.projectPreferences.oldStatus === status.FETCH_READY) {
-        props.dispatch(fetchOldProjectPreferences(props.user.id));
-      }
-      if (props.recents.status === status.FETCH_READY) {
-        props.dispatch(fetchRecents());
-      }
-      if (props.talk.status === status.FETCH_READY) {
-        props.dispatch(fetchTalkUser(props.user.id));
-      }
     }
   }
 


### PR DESCRIPTION
moves requests for project preferences, old project preferences, recent classifications and talk user info from landing to field book page, with intent to speed-up landing.

https://relaunch.notesfromnature.org/ reflects changes.