### PR TITLE
Fix to oauth checkCurrent, staging app ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "history": "^2.0.1",
     "isomorphic-fetch": "^2.2.1",
-    "panoptes-client": "^2.11.0",
+    "panoptes-client": "2.11.0",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
     "react-redux": "^4.4.0",

--- a/src/actions/login.js
+++ b/src/actions/login.js
@@ -1,4 +1,3 @@
-import auth from 'panoptes-client/lib/auth';
 import oauth from 'panoptes-client/lib/oauth';
 import * as type from 'constants/actions';
 import { config } from 'constants/config';
@@ -9,7 +8,7 @@ export function setLoginUser(user) {
 
 // First thing on app load - check if the user is logged in.
 export function checkLoginUser() {
-  return (dispatch) => auth.checkCurrent().then(user => dispatch(setLoginUser(user)));
+  return (dispatch) => oauth.checkCurrent().then(user => dispatch(setLoginUser(user)));
 }
 
 // Returns a login page URL for the user to navigate to.

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -4,7 +4,7 @@ const envConfig = {
     oldProjectId: '1613',
     workflowUrl: 'https://pfe-preview.zooniverse.org/projects/rafe-dot-lafrance/notes-from-nature-on-staging/classify?reload=1&',
     panoptesReturnUrl: 'http://localhost:3000/',
-    panoptesAppId: '24ad5676d5d25c6aa850dc5d5f63ec8c03dbc7ae113b6442b8571fce6c5b974c',
+    panoptesAppId: '16ac801e4ad438d929d30668206df31294e7a7222ce3f449a1c4b45cd80d44cc',
   },
   production: {
     projectId: '1558',


### PR DESCRIPTION
I think this should fix #344 and #78.

Changed checkCurrent method from auth to oauth, set `panoptes-client` version just in case, and made new staging app.